### PR TITLE
feat: allow for customized image widths

### DIFF
--- a/src/_baseline.scss
+++ b/src/_baseline.scss
@@ -160,5 +160,4 @@ small,
 /// @group Responsive
 img {
   display: block;
-  width: 100%;
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

No longer set image width globally

**Fixes:** #13 

## Summary:

Image no longer globally gets set by baseline styles. Now img width can be set normally (e.g. `<img width="500" />`)

## Type of change:

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
